### PR TITLE
Cache embeddings and wire up Flask

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,6 +1,32 @@
+import os
+
 from flask import Flask
 
-app = Flask(__name__)
+from app import config
+
+
+CONFIG = {
+    "development": "app.config.DevelopmentConfig",
+    "test": "app.config.TestConfig",
+    "production": "app.config.ProductionConfig",
+    "default": "app.config.DevelopmentConfig",
+}
+
+app = Flask(__name__,)
+
+# initialize configuration values
+app.logger.debug("Reading configuration...")
+config_name = os.getenv("FLASK_ENV", 'default')
+app.logger.debug("FLASK_ENV is " + config_name)
+
+config_obj = CONFIG[config_name]
+app.logger.debug("config obj: " + config_obj)
+app.config.from_object(config_obj)
+
+if app.config.from_pyfile('config.py'):
+    app.logger.info("Successfully read instance configuration file.")
+app.logger.info("Flask config variables:")
+app.logger.info(app.config.items())
 
 from app import routes  # nopep8
 from app import task_routes  # nopep8

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,6 +1,7 @@
+import logging
 import os
 
-from flask import Flask
+from flask import Flask, current_app
 
 from app import config
 
@@ -26,6 +27,10 @@ if app.config.from_pyfile('config.py'):
     app.logger.info("Successfully read instance configuration file.")
 app.logger.info("Flask config:")
 app.logger.info(app.config.items())
+
+# configure logging
+if not app.debug:
+    app.logger.setLevel(logging.INFO)
 
 from app import routes  # nopep8
 from app import task_routes  # nopep8

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -12,12 +12,11 @@ CONFIG = {
     "default": "app.config.DevelopmentConfig",
 }
 
-app = Flask(__name__,)
+app = Flask(__name__)
 
 # initialize configuration values
-app.logger.debug("Reading configuration...")
 config_name = os.getenv("FLASK_ENV", 'default')
-app.logger.debug("FLASK_ENV is " + config_name)
+app.logger.debug("Reading " + config_name + " configuration...")
 
 config_obj = CONFIG[config_name]
 app.logger.debug("config obj: " + config_obj)
@@ -25,7 +24,7 @@ app.config.from_object(config_obj)
 
 if app.config.from_pyfile('config.py'):
     app.logger.info("Successfully read instance configuration file.")
-app.logger.info("Flask config variables:")
+app.logger.info("Flask config:")
 app.logger.info(app.config.items())
 
 from app import routes  # nopep8

--- a/app/classifier.py
+++ b/app/classifier.py
@@ -1,0 +1,18 @@
+from app import embedder
+
+
+class Classifier:
+
+    def __init__(self):
+        self.embedder = embedder.Embedder()
+
+    def classify(self):
+        # calculate UID of seqs
+        # fetch embedding matrix from the cache
+        #   if it exists, return it
+        #   create and store embedding, return it
+        # classify seq, with its embedding matrix, using a specific model
+        # filter results
+        # map results back to topic strings, according to classifier metadata
+        # return topic confidence array
+        return

--- a/app/config.py
+++ b/app/config.py
@@ -1,6 +1,5 @@
-"""This configuration is read at Flask initialization,
-and conditioned on the FLASK_ENV environment variable
-(usually configured in ../.flaskenv)."""
+"""This configuration is read at Flask initialization, and conditioned on the
+FLASK_ENV environment variable (usually configured in ../.flaskenv)."""
 
 
 class Config(object):
@@ -14,7 +13,7 @@ class ProductionConfig(Config):
 
 class DevelopmentConfig(Config):
     DATABASE_URI = 'mongodb://local'
-    DEBUG = False
+    DEBUG = True
 
 
 class TestConfig(Config):

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,22 @@
+"""This configuration is read at Flask initialization,
+and conditioned on the FLASK_ENV environment variable
+(usually configured in ../.flaskenv)."""
+
+
+class Config(object):
+    DEBUG = False
+    TESTING = False
+
+
+class ProductionConfig(Config):
+    DATABASE_URI = 'mongodb://prod'
+
+
+class DevelopmentConfig(Config):
+    DATABASE_URI = 'mongodb://local'
+    DEBUG = False
+
+
+class TestConfig(Config):
+    DATABASE_URI = 'mongodb://test'
+    TESTING = True

--- a/app/embedder.py
+++ b/app/embedder.py
@@ -58,9 +58,9 @@ class Embedder:
             return matrix
 
         logging.info("Embedding matrix for bert=%s, seq=%s "
-                        "not found in cache. Generating..." %
-                        (self.bert, seq))
-        matrix = self.embed(seq)
+                     "not found in cache. Generating..." %
+                     (self.bert, seq))
+        matrix = self.buildEmbedding(seq)
 
         # convert numpyArray to list for storage in MongoDB
         l_matrix = matrix.tolist()
@@ -70,7 +70,7 @@ class Embedder:
         logging.info("Embedding matrix stored in MongoDB.")
         return matrix
 
-    def embed(self, seq: str):
+    def buildEmbedding(self, seq: str):
         tokens = self.tokenizer.tokenize(seq)
         if len(tokens) > MAX_SEQ_LENGTH - 2:
             tokens = tokens[:(MAX_SEQ_LENGTH - 2)]

--- a/app/embedder.py
+++ b/app/embedder.py
@@ -1,4 +1,12 @@
-from bert import tokenization
+import logging
+from bert import tokenization as token
+from datetime import datetime
+from ming import Field
+from ming import schema
+from ming import Session
+from ming import create_datastore
+from ming.declarative import Document
+import numpy
 import tensorflow as tf
 import tensorflow_hub as hub
 
@@ -6,19 +14,71 @@ import tensorflow_hub as hub
 # padded to equivalent vector lengths.
 MAX_SEQ_LENGTH = 256
 
+bind = create_datastore('tutorial')
+session = Session(bind)
+
+
+class Embedding(Document):
+    """Python representation of embedding cache schema in MongoDB."""
+
+    class __mongometa__:
+        session = session
+        name = 'embedding_matrix'
+
+    _id = Field(schema.ObjectId)
+    bert = Field(schema.String)
+    seq = Field(schema.String)
+    embedding = Field(schema.Array(schema.Array(schema.Float)))
+    update_timestamp = Field(datetime, if_missing=datetime.utcnow)
+
 
 class Embedder:
     def __init__(self, bert: str):
-        self.bert = hub.Module(bert, trainable=True)
+        self.bert = bert
+        self.tf_hub = hub.Module(bert, trainable=True)
 
-        tokenization_info = self.bert(
-            signature="tokenization_info", as_dict=True)
+        t_info = self.tf_hub(signature="tokenization_info", as_dict=True)
         with tf.Session() as sess:
             # vocab_file is a BERT-global, stable mapping {tokens: ids}
-            vocab_file, do_lower_case = sess.run([tokenization_info["vocab_file"],
-                                                  tokenization_info["do_lower_case"]])
-        self.tokenizer = tokenization.FullTokenizer(
-            vocab_file=vocab_file, do_lower_case=do_lower_case)
+            vocab_file, do_lower_case = sess.run(
+                [t_info["vocab_file"],
+                 t_info["do_lower_case"]])
+            self.tokenizer = token.FullTokenizer(
+                vocab_file=vocab_file,
+                do_lower_case=do_lower_case)
+
+    def GetEmbedding(self, seq: str):
+        # fetch from MongoDB
+        obj = Embedding.m.get(bert=self.bert, seq=seq)
+        # if DNE, create and store in MongoDB
+        if not obj:
+            logging.info("Embedding matrix for bert=%s, seq=%s "
+                         "not found in cache. Generating..." %
+                         (self.bert, seq))
+            matrix = self.embed(seq)
+            print(type(matrix))
+            print(type(matrix[0]))
+            print(type(matrix[0][0]))
+            # convert numpyArray to list
+            l_matrix = matrix.tolist()
+            print(type(l_matrix))
+            print(type(l_matrix[0]))
+            print(type(l_matrix[0][0]))
+
+            e = Embedding.make(
+                dict(bert=self.bert, seq=seq, embedding=l_matrix))
+            e.m.save()
+            logging.info("Embedding matrix stored in MongoDB.")
+            return matrix
+
+        logging.info("Using embedding matrix fetched from MongoDB...")
+        # convert list back to numpyArray
+        matrix = numpy.array(obj.embedding)
+        print(type(matrix))
+        print(type(matrix[0]))
+        print(type(matrix[0][0]))
+        logging.debug(matrix)
+        return matrix
 
     def embed(self, seq: str):
         tokens = self.tokenizer.tokenize(seq)
@@ -54,7 +114,7 @@ class Embedder:
         bert_inputs = dict(input_ids=tf.expand_dims(input_ids, 0),
                            input_mask=tf.expand_dims(input_mask, 0),
                            segment_ids=tf.expand_dims(segment_ids, 0))
-        bert_outputs = self.bert(inputs=bert_inputs, signature="tokens",
+        bert_outputs = self.tf_hub(inputs=bert_inputs, signature="tokens",
                                  as_dict=True)
 
         seq_output = bert_outputs["sequence_output"]
@@ -62,7 +122,4 @@ class Embedder:
         with tf.Session() as sess:
             sess.run([tf.global_variables_initializer(), tf.tables_initializer()])
             out = sess.run(seq_output)[0][0:len(tokens)]
-            print("\n")
-            print(out)
-            print("\n")
             return out

--- a/app/routes.py
+++ b/app/routes.py
@@ -24,8 +24,17 @@ def classify():
     return "Classification goes here"
 
 
+@app.route('/embed', methods=['POST'])
+def make_embed():
+    # request.args: {'bert': 'bert_uncased_L-12_H-768_A-12/1'}
+    error = None
+    e = embedder.Embedder(request.form['bert'])
+    matrix = e.GetEmbedding(request.form['seq'])
+    return str(len(matrix))
+
+
 @app.route('/embed/<uuid:id>', methods=['GET'])
-def embed():
+def fetch_embed(id):
     e = embedder.Embedder()
     e.embed()
     return "Embedding goes here"

--- a/app/routes.py
+++ b/app/routes.py
@@ -36,5 +36,5 @@ def make_embed():
 @app.route('/embed/<uuid:id>', methods=['GET'])
 def fetch_embed(id):
     e = embedder.Embedder()
-    e.embed()
+    e._buildEmbedding()
     return "Embedding goes here"

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,10 +1,31 @@
-from flask import request
-from app import app
-from app import tasks
 import json
+
+from app import app
+from app import classifier
+from app import embedder
+from app import tasks
+
+from flask import request
 
 
 @app.route('/')
 @app.route('/index')
 def index():
     return "Hello, World!"
+
+
+@app.route('/classify', methods=['POST'])
+def classify():
+    # request.args: {'classifier': 'bert_for_countries'}
+    # request.form: {'seq1', 'seq2', 'seq3'}
+    error = None
+    c = classifier.Classifier()
+    c.classify()
+    return "Classification goes here"
+
+
+@app.route('/embed/<uuid:id>', methods=['GET'])
+def embed():
+    e = embedder.Embedder()
+    e.embed()
+    return "Embedding goes here"

--- a/local.py
+++ b/local.py
@@ -17,8 +17,8 @@ flags.DEFINE_enum("mode", "embed", ["embed", "classify"], "The operation to perf
 def main(argv):
     if FLAGS.mode == "embed":
         e = embedder.Embedder(FLAGS.bert)
-        print(e.embed(FLAGS.seq))
-        print(len(e.embed(FLAGS.seq).tostring()))
+        m = e.GetEmbedding(FLAGS.seq)
+        print(len(m.tostring()))
     elif FLAGS.mode == "classify":
         print("It's classified.")
         pass

--- a/local.py
+++ b/local.py
@@ -1,7 +1,7 @@
 "local.py is a way to test the app's functionality without starting a server, not used in prod."
 
 import os
-from app import embed
+from app import embedder
 from absl import app
 from absl import flags
 import tensorflow_hub as hub
@@ -11,14 +11,17 @@ FLAGS = flags.FLAGS
 flags.DEFINE_string(
     "bert", "https://tfhub.dev/google/bert_uncased_L-12_H-768_A-12/1", "The bert model to use")
 flags.DEFINE_string("seq", "", "The sequence to handle")
-flags.DEFINE_enum("mode", "embed", ["embed"], "The operation to perform.")
+flags.DEFINE_enum("mode", "embed", ["embed", "classify"], "The operation to perform.")
 
 
 def main(argv):
     if FLAGS.mode == "embed":
-        e = embed.Embedder(FLAGS.bert)
+        e = embedder.Embedder(FLAGS.bert)
         print(e.embed(FLAGS.seq))
         print(len(e.embed(FLAGS.seq).tostring()))
+    elif FLAGS.mode == "classify":
+        print("It's classified.")
+        pass
 
 
 if __name__ == '__main__':

--- a/local.py
+++ b/local.py
@@ -27,4 +27,3 @@ def main(argv):
 if __name__ == '__main__':
     os.environ['TFHUB_CACHE_DIR'] = os.getcwd() + "/bert_models"
     app.run(main)
-buildEmbedding

--- a/local.py
+++ b/local.py
@@ -27,3 +27,4 @@ def main(argv):
 if __name__ == '__main__':
     os.environ['TFHUB_CACHE_DIR'] = os.getcwd() + "/bert_models"
     app.run(main)
+buildEmbedding

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ tensorflow-gpu==1.15.0
 tensorflow-hub
 numpy
 bert-tensorflow
+ming
 
 # Dev:
 pip

--- a/server.py
+++ b/server.py
@@ -1,1 +1,4 @@
 from app import app
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/server.py
+++ b/server.py
@@ -1,4 +1,8 @@
 from app import app
+from absl import flags
+
+FLAGS = flags.FLAGS
+
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    app.run(debug=False, threaded=True)


### PR DESCRIPTION
- Initially populate and wire up Flask configuration for a plurality of environments
- Define some basic endpoints (e.g. /embed and /classify) with placeholder functionality for now
- Define a MongoDB entity schema for Embeddings
- Wire up the local invocation of embed to write to and read from the MongoDB cache of embeddings
- Wire up /embed to the embedding impl with a cache (try with `./run server && curl -d "bert=https://tfhub.dev/google/bert_uncased_L-12_H-768_A-12/1&seq=helloworld" -X POST http://localhost:5000/embed`